### PR TITLE
Fix some End proofs

### DIFF
--- a/src/storage.k.md
+++ b/src/storage.k.md
@@ -649,7 +649,7 @@ syntax Int ::= "#End.pot" [function]
 // ---------------------------------
 // doc: `Pot` that this `End` points to
 // act:
-rule #End.spot => 4
+rule #End.pot => 4
 
 syntax Int ::= "#End.spot" [function]
 // ---------------------------------


### PR DESCRIPTION
Copy-paste error in storage. Fixes at least the following three proofs:
End_file-addr_pass_rough
End_file-addr_fail_rough
End_spot_pass_rough