### PR TITLE
Update Makefile build to 0.5.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: dapp spec
 dapp:
 	dapp --version
 	git submodule update --init --recursive
-	cd $(DAPP_DIR) && dapp --use solc:0.5.9 build && cd ../
+	cd $(DAPP_DIR) && dapp --use solc:0.5.11 build && cd ../
 
 dapp-clean:
 	cd $(DAPP_DIR) && dapp clean && cd ../


### PR DESCRIPTION
Updated in case this was an oversight. DSS contracts are now on 0.5.11.