### PR TITLE
fix cage-ilk proofs

### DIFF
--- a/src/dss.md
+++ b/src/dss.md
@@ -9031,7 +9031,7 @@ storage
 storage Spotter
   ilks[ilk].pip |-> DSValue
   ilks[ilk].mat |-> Mat_i
-  ilks[ilk].par |-> Par
+  par           |-> Par
 
 storage Vat
   ilks[ilk].Art  |-> Art_i


### PR DESCRIPTION
copy-paste error in `cage-ilk` act corrected (confirmed that proofs pass)