### PR TITLE
Vow cage

### DIFF
--- a/src/dss.md
+++ b/src/dss.md
@@ -8685,7 +8685,7 @@ iff
     VCallValue == 0
     VCallDepth < 1022
     Live == 1
-    VowLive == 0
+    VowLive == 1
     CallerMay == 1
     EndMayVat == 1
     EndMayCat == 1
@@ -8825,7 +8825,7 @@ iff
     VCallValue == 0
     VCallDepth < 1022
     Live == 1
-    VowLive == 0
+    VowLive == 1
     CallerMay == 1
     EndMayVat == 1
     EndMayCat == 1
@@ -8965,7 +8965,7 @@ iff
     VCallValue == 0
     VCallDepth < 1022
     Live == 1
-    VowLive == 0
+    VowLive == 1
     CallerMay == 1
     EndMayVat == 1
     EndMayCat == 1

--- a/src/dss.md
+++ b/src/dss.md
@@ -4517,6 +4517,7 @@ iff
 
     VCallValue == 0
     VCallDepth < 1023
+    Live == 1
     Can == 1
     MayFlap == 1
     MayFlop == 1
@@ -4603,6 +4604,7 @@ iff
 
     VCallValue == 0
     VCallDepth < 1023
+    Live == 1
     Can == 1
     MayFlap == 1
     MayFlop == 1

--- a/src/dss.md
+++ b/src/dss.md
@@ -4429,6 +4429,7 @@ iff
 
     VCallValue == 0
     VCallDepth < 1023
+    Live == 1
     Can == 1
     MayFlap == 1
     MayFlop == 1


### PR DESCRIPTION
Fix `Vow.cage-*` proofs. Also fix related conditions in `End.cage-*` proofs. Partially tested the changes to the `Vow` acts (`Vow_cage-surplus_pass_rough`, `Vow_cage-surplus_fail_rough`, and `Vow_cage-deficit_pass_rough` are all accepting).