### PR TITLE
Pin z3 to 6ec8fe0 of nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,10 @@
 with import <nixpkgs> {};
+let
+  pkgs-6ec8fe0 = import (fetchGit {
+    url = "https://github.com/NixOS/nixpkgs";
+    rev = "6ec8fe0408d8940dcbeea6b01cab071062fd8f2d";
+  }) {};
+in
 stdenv.mkDerivation {
   name = "k-dss";
   buildInputs = [
@@ -14,7 +20,7 @@ stdenv.mkDerivation {
     parallel
     wget
     zip
-    z3
+    pkgs-6ec8fe0.z3
   ];
   shellHook = ''
     if [ -z "$KLAB_PATH" ]; then echo "WARNING: The environment variable KLAB_PATH should be set to point to the klab repo. Please fix and reënter the nix shell."; fi


### PR DESCRIPTION
@nanexcool here is an example of how to pin a dependency.

This is not an optimal solution though, because we can't override the version of `z3` when `nix-shell` is invoked.

The best solution would be to refactor `shell.nix` so that we can inject and override any dependency instead.