### PR TITLE
Spec updates

### DIFF
--- a/src/dss.md
+++ b/src/dss.md
@@ -4432,10 +4432,10 @@ storage
 
 storage Vat
 
-    dai[ACCT_ID] |-> Joy  => Joy  - rad
     sin[ACCT_ID] |-> Awe  => Awe  - rad
-    vice         |-> Vice => Vice - rad
+    dai[ACCT_ID] |-> Joy  => Joy  - rad
     debt         |-> Debt => Debt - rad
+    vice         |-> Vice => Vice - rad
 
 iff
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -2146,7 +2146,7 @@ types
 storage
 
     balanceOf[CALLER_ID] |-> SrcBal => SrcBal - wad
-    balanceOf[dst]        |-> DstBal => DstBal + wad
+    balanceOf[dst]       |-> DstBal => DstBal + wad
 
 iff in range uint256
 
@@ -7240,9 +7240,9 @@ storage Vat
 
 storage Dai
 
+    allowance[CALLER_ID][ACCT_ID] |-> Allowed => #if Allowed == maxUInt256 #then Allowed #else Allowed - wad #fi
     balanceOf[CALLER_ID]          |-> Dai_c   => Dai_c - wad
     totalSupply                   |-> Supply  => Supply - wad
-    allowance[CALLER_ID][ACCT_ID] |-> Allowed => #if Allowed == maxUInt256 #then Allowed #else Allowed - wad #fi
 
 iff
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -6298,8 +6298,8 @@ storage
 
 storage Vat
   can[CALLER_ID][ACCT_ID] |-> Can
-  dai[Gal]       |-> Dai_g => Dai_g + (bid - Bid)
   dai[CALLER_ID] |-> Dai_c => Dai_c - (bid - Bid)
+  dai[Gal]       |-> Dai_g => Dai_g + (bid - Bid)
 
 iff
   VCallValue == 0
@@ -9832,6 +9832,7 @@ if
     VowVat  == Vat
     VowVat  =/= Vow
     FlapVat =/= Vow
+    Spotter =/= VowVat
 
 calls
     Vat.cage

--- a/src/dss.md
+++ b/src/dss.md
@@ -29,9 +29,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1236
 ```
 
 #### allowances
@@ -53,9 +50,6 @@ iff
     VCallValue == 0
 
 returns Can
-
-gas
-    1313
 ```
 
 #### collateral type data
@@ -87,9 +81,6 @@ iff
     VCallValue == 0
 
 returns Ilk_Art : Ilk_rate : Ilk_spot : Ilk_line : Ilk_dust
-
-gas
-    4594
 ```
 
 #### `urn` data
@@ -115,9 +106,6 @@ iff
     VCallValue == 0
 
 returns Ink_iu : Art_iu
-
-gas
-    2153
 ```
 
 #### internal unencumbered collateral balances
@@ -141,9 +129,6 @@ iff
     VCallValue == 0
 
 returns Gem
-
-gas
-    1352
 ```
 
 #### internal dai balances
@@ -167,9 +152,6 @@ iff
     VCallValue == 0
 
 returns Rad
-
-gas
-    1236
 ```
 
 #### internal sin balances
@@ -193,9 +175,6 @@ iff
     VCallValue == 0
 
 returns Rad
-
-gas
-    1235
 ```
 
 #### total debt
@@ -217,9 +196,6 @@ iff
     VCallValue == 0
 
 returns Debt
-
-gas
-    1052
 ```
 
 #### total bad debt
@@ -241,9 +217,6 @@ iff
     VCallValue == 0
 
 returns Vice
-
-gas
-    1095
 ```
 
 #### debt ceiling
@@ -265,9 +238,6 @@ iff
     VCallValue == 0
 
 returns Line
-
-gas
-    1116
 ```
 
 #### system liveness flag
@@ -289,9 +259,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1095
 ```
 
 ### Lemmas
@@ -313,9 +280,6 @@ iff in range uint256
 if
 
    #sizeWordStack(WS) <= 1015
-
-gas
-    (#if ( ( 0 <=Int ABI_y ) andBool ( #unsigned(ABI_y) <=Int 0 ) ) #then ( 114 ) #else ( 128 ) #fi)
 ```
 
 ```act
@@ -333,9 +297,6 @@ iff in range uint256
 if
 
     #sizeWordStack(WS) <= 1015
-
-gas
-    (#if ( ( ABI_y <=Int 0 ) andBool ( 0 <=Int ABI_y ) ) #then ( 114 ) #else ( 128 ) #fi)
 ```
 
 ```act
@@ -355,9 +316,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    (#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi)
 ```
 
 ```act
@@ -376,9 +334,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -397,9 +352,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -418,9 +370,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    (#if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi)
 ```
 
 ### Mutators
@@ -448,9 +397,6 @@ iff
 
     VCallValue == 0
     May == 1
-
-gas
-    (#if ( ( Lives ==K 0 ) orBool (notBool ( Junk_1 ==K Lives ) ) ) #then 0 #else 4200 #fi) +Int 6245
 ```
 
 
@@ -509,9 +455,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    7293
 ```
 
 ```act
@@ -539,9 +482,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 7248
 ```
 
 ```act
@@ -568,9 +508,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 7248
 ```
 
 ```act
@@ -597,9 +534,6 @@ storage
 iff
 
     VCallValue == 0
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_1 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 5601
 ```
 
 #### initialising an `ilk`
@@ -1798,9 +1732,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1257
 ```
 
 ```act
@@ -1820,9 +1751,6 @@ iff
     VCallValue == 0
 
 returns Allowed
-
-gas
-    1377
 ```
 
 ```act
@@ -1842,9 +1770,6 @@ iff
     VCallValue == 0
 
 returns Balance
-
-gas
-    1302
 ```
 
 ```act
@@ -1864,9 +1789,6 @@ iff
     VCallValue == 0
 
 returns Supply
-
-gas
-    1073
 ```
 
 ```act
@@ -1886,9 +1808,6 @@ iff
     VCallValue == 0
 
 returns Nonce
-
-gas
-    1192
 ```
 
 ```act
@@ -1900,9 +1819,6 @@ iff
     VCallValue == 0
 
 returns 18
-
-gas
-    240
 ```
 
 ```act
@@ -1914,9 +1830,6 @@ iff
     VCallValue == 0
 
 returnsRaw #asByteStackInWidthaux(32, 31, 32, #enc(#string("Dai Stablecoin")))
-
-gas
-    629
 ```
 
 ```act
@@ -1928,9 +1841,6 @@ iff
     VCallValue == 0
 
 returnsRaw #asByteStackInWidthaux(32, 31, 32, #enc(#string("1")))
-
-gas
-    694
 ```
 
 ```act
@@ -1942,9 +1852,6 @@ iff
     VCallValue == 0
 
 returnsRaw #asByteStackInWidthaux(32, 31, 32, #enc(#string("DAI")))
-
-gas
-    672
 ```
 
 ```act
@@ -1956,9 +1863,6 @@ iff
     VCallValue == 0
 
 returns keccak(#parseByteStackRaw("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)"))
-
-gas
-    323
 ```
 
 ```act
@@ -1978,9 +1882,6 @@ iff
     VCallValue == 0
 
 returns Dom
-
-gas
-    1050
 ```
 
 ### Mutators
@@ -2034,9 +1935,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6487
 ```
 
 ```act
@@ -2061,9 +1959,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6465
 ```
 
 ```act
@@ -2087,9 +1982,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6465
 ```
 
 ```act
@@ -2108,9 +2000,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -2129,9 +2018,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -2504,9 +2390,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1235
 ```
 
 #### `ilk` data
@@ -2532,9 +2415,6 @@ iff
     VCallValue == 0
 
 returns Duty : Rho
-
-gas
-    2119
 ```
 
 #### `vat` address
@@ -2556,9 +2436,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1098
 ```
 
 #### `vow` address
@@ -2580,9 +2457,6 @@ iff
     VCallValue == 0
 
 returns Vow
-
-gas
-    1053
 ```
 
 #### global interest rate
@@ -2604,9 +2478,6 @@ iff
     VCallValue == 0
 
 returns Base
-
-gas
-    1116
 ```
 
 
@@ -2658,9 +2529,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6398
 ```
 
 ```act
@@ -2685,9 +2553,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6420
 ```
 
 ```act
@@ -2711,9 +2576,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6420
 ```
 
 #### initialising an `ilk`
@@ -2917,9 +2779,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 This is the coinductive lemma.
@@ -2945,8 +2804,6 @@ This is the coinductive lemma.
 
 num0 n := "number of 0 in n"
 num1 n := "number of 1 in n"
-
-gas = 194 + num0(n) * 178 + num1(n) * 293
 ```
 
 ```act
@@ -2970,10 +2827,6 @@ stack
 
     _ : _ : Half : _ : Z : Base : N : X : WS => Half : _ : #rpow(Z, X, N, Base) : Base : 0 : _ : WS
 
-gas
-
-    194 + ((num0(N) * 172) + (num1(N) * 287))
-
 if
 
     Half == Base / 2
@@ -2994,10 +2847,6 @@ interface rpow(uint256 x, uint256 n, uint256 b) internal
 stack
 
     b : n : x : JMPTO : WS => JMPTO : #rpow(b, x, n, b) : WS
-
-gas
-
-    (#if ( ABI_x ==K 0 ) #then (#if ( ABI_n ==K 0 ) #then 82 #else 92 #fi) #else (#if ( ( ABI_n modInt 2 ) ==K 0 ) #then (#if ( ( ABI_n /Int 2 ) ==K 0 ) #then 150 #else ( 437 +Int ( ( ( num0(ABI_n) -Int 1 ) *Int 172 ) +Int ( num1(ABI_n) *Int 287 ) ) ) #fi) #else (#if ( ( ABI_n /Int 2 ) ==K 0 ) #then 160 #else ( 447 +Int ( ( num0(ABI_n) *Int 172 ) +Int ( ( num1(ABI_n) -Int 1 ) *Int 287 ) ) ) #fi) #fi) #fi)
 
 if
 
@@ -3038,9 +2887,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -3059,9 +2905,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -3079,9 +2922,6 @@ iff in range uint256
 if
 
     #sizeWordStack(WS) <= 1000
-
-gas
-    (#if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi)
 ```
 
 ```act
@@ -3100,9 +2940,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    (#if ( ABI_y ==K 0 ) #then ( 127 ) #else ( 179 ) #fi)
 ```
 
 
@@ -3127,9 +2964,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1235
 ```
 
 #### deposit balances
@@ -3151,9 +2985,6 @@ iff
     VCallValue == 0
 
 returns Pie_usr
-
-gas
-    1215
 ```
 
 #### total deposits
@@ -3175,9 +3006,6 @@ iff
     VCallValue == 0
 
 returns Pie_tot
-
-gas
-    1028
 ```
 
 #### savings interest rate
@@ -3199,9 +3027,6 @@ iff
     VCallValue == 0
 
 returns Dsr
-
-gas
-    1072
 ```
 
 #### savings interest rate accumulator
@@ -3223,9 +3048,6 @@ iff
     VCallValue == 0
 
 returns Chi
-
-gas
-    1093
 ```
 
 #### `Vat` address
@@ -3247,9 +3069,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1098
 ```
 
 #### `Vow` address
@@ -3271,9 +3090,6 @@ iff
     VCallValue == 0
 
 returns Vow
-
-gas
-    1142
 ```
 
 #### last `drip` time
@@ -3295,9 +3111,6 @@ iff
     VCallValue == 0
 
 returns Rho
-
-gas
-    1073
 ```
 
 #### system liveness flag
@@ -3319,9 +3132,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1094
 ```
 
 ### Mutators
@@ -3372,9 +3182,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6399
 ```
 
 ```act
@@ -3399,9 +3206,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 ```act
@@ -3425,9 +3229,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 #### setting the savings rate
@@ -3531,10 +3332,6 @@ stack
 
     _ : _ : Half : _ : Z : Base : N : X : WS => Half : _ : #rpow(Z, X, N, Base) : Base : 0 : _ : WS
 
-gas
-
-    194 + ((num0(N) * 172) + (num1(N) * 287))
-
 if
 
     Half == Base / 2
@@ -3555,10 +3352,6 @@ interface rpow(uint256 x, uint256 n, uint256 b) internal
 stack
 
     b : n : x : JMPTO : WS => JMPTO : #rpow(b, x, n, b) : WS
-
-gas
-
-    (#if ( ABI_x ==K 0 ) #then (#if ( ABI_n ==K 0 ) #then 82 #else 92 #fi) #else (#if ( ( ABI_n modInt 2 ) ==K 0 ) #then (#if ( ( ABI_n /Int 2 ) ==K 0 ) #then 150 #else ( 437 +Int ( ( ( num0(ABI_n) -Int 1 ) *Int 172 ) +Int ( num1(ABI_n) *Int 287 ) ) ) #fi) #else (#if ( ( ABI_n /Int 2 ) ==K 0 ) #then 160 #else ( 447 +Int ( ( num0(ABI_n) *Int 172 ) +Int ( ( num1(ABI_n) -Int 1 ) *Int 287 ) ) ) #fi) #fi) #fi)
 
 
 if
@@ -3779,9 +3572,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -3800,9 +3590,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -3816,9 +3603,6 @@ stack
 if
 
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_x <=Int ABI_y ) #then ( 49 ) #else ( 59 ) #fi
 ```
 
 ### Accessors
@@ -3842,9 +3626,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1280
 ```
 
 #### getting the `Vat`
@@ -3866,9 +3647,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1187
 ```
 
 #### getting the `Flapper`
@@ -3890,9 +3668,6 @@ iff
     VCallValue == 0
 
 returns Flapper
-
-gas
-    1098
 ```
 
 #### getting the `Flopper`
@@ -3914,9 +3689,6 @@ iff
     VCallValue == 0
 
 returns Flopper
-
-gas
-    1076
 ```
 
 #### getting a `sin` packet
@@ -3938,9 +3710,6 @@ iff
     VCallValue == 0
 
 returns Sin_era
-
-gas
-    1185
 ```
 
 #### getting the `Sin`
@@ -3962,9 +3731,6 @@ iff
     VCallValue == 0
 
 returns Sin
-
-gas
-    1049
 ```
 
 #### getting the `Ash`
@@ -3986,9 +3752,6 @@ iff
     VCallValue == 0
 
 returns Ash
-
-gas
-    1117
 ```
 
 #### getting the `wait`
@@ -4010,9 +3773,6 @@ iff
     VCallValue == 0
 
 returns Wait
-
-gas
-    1072
 ```
 
 #### getting the `dump`
@@ -4034,9 +3794,6 @@ iff
     VCallValue == 0
 
 returns Dump
-
-gas
-    1115
 ```
 
 #### getting the `sump`
@@ -4058,9 +3815,6 @@ iff
     VCallValue == 0
 
 returns Sump
-
-gas
-    1138
 ```
 
 #### getting the `bump`
@@ -4082,9 +3836,6 @@ iff
     VCallValue == 0
 
 returns Bump
-
-gas
-    1116
 ```
 
 #### getting the `hump`
@@ -4106,9 +3857,6 @@ iff
     VCallValue == 0
 
 returns Hump
-
-gas
-    1051
 ```
 
 #### getting the `live` flag
@@ -4130,9 +3878,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1050
 ```
 
 ### Mutators
@@ -4189,9 +3934,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    7288
 ```
 
 ```act
@@ -4216,9 +3958,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6443
 ```
 
 ```act
@@ -4242,9 +3981,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6443
 ```
 
 #### setting `Vow` parameters
@@ -5010,9 +4746,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1213
 ```
 
 #### `ilk` data
@@ -5038,9 +4771,6 @@ iff
     VCallValue == 0
 
 returns Flip : Chop : Lump
-
-gas
-    2977
 ```
 
 #### liveness
@@ -5062,9 +4792,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1005
 ```
 
 #### `vat` address
@@ -5086,9 +4813,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1076
 ```
 
 #### `vow` address
@@ -5110,9 +4834,6 @@ iff
     VCallValue == 0
 
 returns Vow
-
-gas
-    1120
 ```
 
 ### Mutators
@@ -5163,9 +4884,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6465
 ```
 
 ```act
@@ -5190,9 +4908,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 ```act
@@ -5216,9 +4931,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 #### setting contract addresses
@@ -5367,9 +5079,6 @@ iff in range uint256
 if
 
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi
 ```
 
 ```act
@@ -5383,9 +5092,6 @@ stack
 if
 
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_x <=Int ABI_y ) #then ( 49 ) #else ( 59 ) #fi
 ```
 
 ```act
@@ -5708,9 +5414,6 @@ storage
 iff
   Ward == 1
   VCallValue == 0
-
-gas
-    (#if ( ( Live ==K 0 ) orBool (notBool ( Junk_1 ==K Live ) ) ) #then 0 #else 4200 #fi) +Int 6307
 ```
 
 ## Flip: liquidation auction
@@ -5732,9 +5435,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1258
 ```
 
 #### bid data
@@ -5768,9 +5468,6 @@ iff
     VCallValue == 0
 
 returns Bid : Lot : Guy : Tic : End : Usr : Gal : Tab
-
-gas
-    7364
 ```
 
 #### cdp engine
@@ -5792,9 +5489,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1143
 ```
 
 #### collateral type
@@ -5816,9 +5510,6 @@ iff
     VCallValue == 0
 
 returns Ilk
-
-gas
-    1027
 ```
 
 #### minimum bid increment
@@ -5840,9 +5531,6 @@ iff
     VCallValue == 0
 
 returns Beg
-
-gas
-    1050
 ```
 
 #### auction time-to-live
@@ -5865,9 +5553,6 @@ iff
     VCallValue == 0
 
 returns Ttl
-
-gas
-    1120
 ```
 
 #### maximum auction duration
@@ -5890,9 +5575,6 @@ iff
     VCallValue == 0
 
 returns Tau
-
-gas
-    1169
 ```
 
 #### kick counter
@@ -5914,9 +5596,6 @@ iff
     VCallValue == 0
 
 returns Kicks
-
-gas
-    1093
 ```
 
 ### Mutators
@@ -5969,9 +5648,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6399
 ```
 
 ```act
@@ -5996,9 +5672,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6443
 ```
 
 ```act
@@ -6022,9 +5695,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6443
 ```
 
 #### Auction parameters
@@ -6072,9 +5742,6 @@ iff in range uint48
 if
 
     #sizeWordStack(WS) <= 100
-
-gas
-    66
 ```
 
 ```act
@@ -6093,9 +5760,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi
 ```
 
 ```act
@@ -6607,9 +6271,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1235
 ```
 
 #### `vat` address
@@ -6631,9 +6292,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1054
 ```
 
 #### the associated `ilk`
@@ -6655,9 +6313,6 @@ iff
     VCallValue == 0
 
 returns Ilk
-
-gas
-    1093
 ```
 
 #### gem address
@@ -6679,9 +6334,6 @@ iff
     VCallValue == 0
 
 returns Gem
-
-gas
-    1142
 ```
 
 ```act
@@ -6701,9 +6353,6 @@ iff
     VCallValue == 0
 
 returns Dec
-
-gas
-    1049
 ```
 
 ```act
@@ -6723,9 +6372,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1005
 ```
 
 ### Mutators
@@ -6776,9 +6422,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6421
 ```
 
 #### revoking authorisation
@@ -6804,9 +6447,6 @@ iff
 
 if
     usr =/= CALLER_ID
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 ```act
@@ -6829,9 +6469,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 #### depositing into the system
@@ -6976,9 +6613,6 @@ iff
 
     VCallValue == 0
     May == 1
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6263
 ```
 
 # DaiJoin
@@ -7008,9 +6642,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1213
 ```
 
 #### `vat` address
@@ -7032,9 +6663,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1054
 ```
 
 #### `dai` address
@@ -7056,9 +6684,6 @@ iff
     VCallValue == 0
 
 returns Dai
-
-gas
-    1141
 ```
 
 #### `live` flag
@@ -7080,9 +6705,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1005
 ```
 
 ### Mutators
@@ -7132,9 +6754,6 @@ iff
 if
 
     usr == CALLER_ID
-
-gas
-    6421
 ```
 
 #### revoking authorisation
@@ -7160,9 +6779,6 @@ iff
 if
 
     usr =/= CALLER_ID
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 ```act
@@ -7185,9 +6801,6 @@ iff
 if
 
     usr == CALLER_ID
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6398
 ```
 
 #### depositing into the system
@@ -7208,9 +6821,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi
 ```
 
 ```act
@@ -7355,9 +6965,6 @@ iff
 
     May == 1
     VCallValue == 0
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6263
 ```
 
 # Flapper
@@ -7387,9 +6994,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1258
 ```
 
 #### bid data
@@ -7417,9 +7021,6 @@ iff
   VCallValue == 0
 
 returns Bid : Lot : Guy : Tic : End
-
-gas
-    4839
 ```
 
 #### CDP Engine
@@ -7441,9 +7042,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1121
 ```
 
 #### MKR Token
@@ -7465,9 +7063,6 @@ iff
     VCallValue == 0
 
 returns Gem
-
-gas
-    1142
 ```
 
 #### minimum bid increment
@@ -7489,9 +7084,6 @@ iff
     VCallValue == 0
 
 returns Beg
-
-gas
-    1116
 ```
 
 #### auction time-to-live
@@ -7514,9 +7106,6 @@ iff
     VCallValue == 0
 
 returns Ttl
-
-gas
-    1098
 ```
 
 #### maximum auction duration
@@ -7539,9 +7128,6 @@ iff
     VCallValue == 0
 
 returns Tau
-
-gas
-    1169
 ```
 
 #### kick counter
@@ -7563,9 +7149,6 @@ iff
     VCallValue == 0
 
 returns Kicks
-
-gas
-    1093
 ```
 
 #### liveness flag
@@ -7587,9 +7170,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1028
 ```
 
 ### Mutators
@@ -7642,9 +7222,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6443
 ```
 
 ```act
@@ -7669,9 +7246,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6421
 ```
 
 ```act
@@ -7695,9 +7269,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6421
 ```
 
 #### Auction parameters
@@ -7747,9 +7318,6 @@ iff in range uint48
 if
 
     #sizeWordStack(WS) <= 100
-
-gas
-    66
 ```
 
 ```act
@@ -7768,9 +7336,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi
 ```
 
 ```act
@@ -8190,9 +7755,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1191
 ```
 
 
@@ -8222,9 +7784,6 @@ iff
     VCallValue == 0
 
 returns Bid : Lot : Guy : Tic : End
-
-gas
-    4839
 ```
 
 #### CDP Engine
@@ -8246,9 +7805,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1121
 ```
 
 #### MKR Token
@@ -8270,9 +7826,6 @@ iff
     VCallValue == 0
 
 returns Gem
-
-gas
-    1164
 ```
 
 #### Vow address
@@ -8294,9 +7847,6 @@ iff
     VCallValue == 0
 
 returns Vow
-
-gas
-    1098
 ```
 
 #### minimum bid increment
@@ -8318,9 +7868,6 @@ iff
     VCallValue == 0
 
 returns Beg
-
-gas
-    1028
 ```
 
 ```act
@@ -8340,9 +7887,6 @@ iff
     VCallValue == 0
 
 returns Pad
-
-gas
-    1050
 ```
 
 #### auction time-to-live
@@ -8365,9 +7909,6 @@ iff
     VCallValue == 0
 
 returns Ttl
-
-gas
-    1165
 ```
 
 #### maximum auction duration
@@ -8390,9 +7931,6 @@ iff
     VCallValue == 0
 
 returns Tau
-
-gas
-    1169
 ```
 
 #### kick counter
@@ -8414,9 +7952,6 @@ iff
     VCallValue == 0
 
 returns Kicks
-
-gas
-    1093
 ```
 
 #### liveness flag
@@ -8438,9 +7973,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1072
 ```
 
 ### Mutators
@@ -8493,9 +8025,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6443
 ```
 
 ```act
@@ -8520,9 +8049,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6465
 ```
 
 ```act
@@ -8546,9 +8072,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6465
 ```
 
 ```act
@@ -8566,9 +8089,6 @@ iff in range uint48
 if
 
     #sizeWordStack(WS) <= 100
-
-gas
-    66
 ```
 
 ```act
@@ -8587,9 +8107,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi
 ```
 
 #### Auction parameters
@@ -9079,9 +8596,6 @@ iff
 
 if
     usr == CALLER_ID
-
-gas
-    6421
 ```
 
 ```act
@@ -9106,9 +8620,6 @@ iff
 if
 
     CALLER_ID =/= usr
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6421
 ```
 
 ```act
@@ -9132,9 +8643,6 @@ iff
 if
 
     CALLER_ID == usr
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6421
 ```
 
 ### Math Lemmas
@@ -9155,9 +8663,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 ```act
@@ -9176,9 +8681,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 100
-
-gas
-    54
 ```
 
 
@@ -9198,9 +8700,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi
 ```
 
 ```act
@@ -9214,9 +8713,6 @@ stack
 if
 
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_x <=Int ABI_y ) #then ( 49 ) #else ( 59 ) #fi
 ```
 
 ```act
@@ -9235,9 +8731,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 127 ) #else ( 179 ) #fi
 ```
 
 ```act
@@ -9260,9 +8753,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    179
 ```
 
 
@@ -9285,9 +8775,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1236
 ```
 
 ```act
@@ -9307,9 +8794,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1144
 ```
 
 ```act
@@ -9329,9 +8813,6 @@ iff
     VCallValue == 0
 
 returns Cat
-
-gas
-    1097
 ```
 
 #### `vow` address
@@ -9353,9 +8834,6 @@ iff
     VCallValue == 0
 
 returns Vow
-
-gas
-    1099
 ```
 
 #### `pot` address
@@ -9377,9 +8855,6 @@ iff
     VCallValue == 0
 
 returns Pot
-
-gas
-    1121
 ```
 
 #### `spot` address
@@ -9401,9 +8876,6 @@ iff
     VCallValue == 0
 
 returns Spot
-
-gas
-    1164
 ```
 
 #### liveness
@@ -9425,9 +8897,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1095
 ```
 
 ### Setting `End` parameters
@@ -9509,9 +8978,6 @@ iff
     VCallValue == 0
 
 returns When
-
-gas
-    1116
 ```
 
 ### Processing period
@@ -9533,9 +8999,6 @@ iff
     VCallValue == 0
 
 returns Wait
-
-gas
-    1095
 ```
 
 ### Total Outstanding Debt
@@ -9557,9 +9020,6 @@ iff
     VCallValue == 0
 
 returns Debt
-
-gas
-    1052
 ```
 
 ### Ilk Data
@@ -9581,9 +9041,6 @@ iff
     VCallValue == 0
 
 returns Ray
-
-gas
-    1251
 ```
 
 ```act
@@ -9603,9 +9060,6 @@ iff
     VCallValue == 0
 
 returns Wad
-
-gas
-    1229
 ```
 
 ```act
@@ -9625,9 +9079,6 @@ iff
     VCallValue == 0
 
 returns Wad
-
-gas
-    1230
 ```
 
 ```act
@@ -9647,9 +9098,6 @@ iff
     VCallValue == 0
 
 returns Ray
-
-gas
-    1231
 ```
 
 ```act
@@ -9669,9 +9117,6 @@ iff
     VCallValue == 0
 
 returns Wad
-
-gas
-    1237
 ```
 
 ```act
@@ -9691,9 +9136,6 @@ iff
     VCallValue == 0
 
 returns Wad
-
-gas
-    1372
 ```
 
 ## Behaviours
@@ -10987,9 +10429,6 @@ iff
   VCallValue == 0
 
 returns Supply
-
-gas
-    1125
 ```
 
 ```act
@@ -11006,9 +10445,6 @@ iff
   VCallValue == 0
 
 returns BalanceOf
-
-gas
-    1307
 ```
 
 ```act
@@ -11025,9 +10461,6 @@ iff
   VCallValue == 0
 
 returns Allowance
-
-gas
-    1409
 ```
 
 ```act
@@ -11276,9 +10709,6 @@ iff
   VCallValue == 0
 
 returns Value : Ok
-
-gas
-    2012
 ```
 
 ```act
@@ -11299,9 +10729,6 @@ iff
   Ok == 1
 
 returns Value
-
-gas
-    2043
 ```
 
 # Spotter
@@ -11329,9 +10756,6 @@ iff
     VCallValue == 0
 
 returns May
-
-gas
-    1235
 ```
 
 #### ilks
@@ -11355,9 +10779,6 @@ iff
     VCallValue == 0
 
 returns Pip : Mat
-
-gas
-    2145
 ```
 
 #### `vat` address
@@ -11379,9 +10800,6 @@ iff
     VCallValue == 0
 
 returns Vat
-
-gas
-    1120
 ```
 
 #### `par` value
@@ -11403,9 +10821,6 @@ iff
     VCallValue == 0
 
 returns Par
-
-gas
-    1094
 ```
 
 #### shutdown flag
@@ -11427,9 +10842,6 @@ iff
     VCallValue == 0
 
 returns Live
-
-gas
-    1027
 ```
 
 ### Mutators
@@ -11479,9 +10891,6 @@ iff
 if
 
     usr == CALLER_ID
-
-gas
-    6487
 ```
 
 ```act
@@ -11505,9 +10914,6 @@ iff
 if
 
     usr =/= CALLER_ID
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6420
 ```
 
 ```act
@@ -11530,9 +10936,6 @@ iff
 if
 
     usr == CALLER_ID
-
-gas
-    (#if (notBool ( Junk_0 ==K 1 ) ) #then 0 #else 4200 #fi) +Int 6420
 ```
 
 #### change governance parameters
@@ -11626,9 +11029,6 @@ iff
 
     May == 1
     VCallValue == 0
-
-gas
-    (#if ( ( Junk_0 ==K 0 ) orBool (notBool ( Junk_2 ==K Junk_0 ) ) ) #then 0 #else 4200 #fi) +Int 6196
 ```
 
 #### update `spot` value
@@ -11649,9 +11049,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    #if ( ABI_y ==K 0 ) #then ( 54 ) #else ( 106 ) #fi
 ```
 
 ```act
@@ -11674,9 +11071,6 @@ if
 
     // TODO: strengthen
     #sizeWordStack(WS) <= 1000
-
-gas
-    179
 ```
 
 ```act

--- a/src/dss.md
+++ b/src/dss.md
@@ -8809,8 +8809,8 @@ storage Vow
 storage Vat
   can[CALLER_ID][ACCT_ID]   |-> CanMove
   dai[CALLER_ID]            |-> Dai_a => Dai_a - bid
-  dai[Vow]                  |-> Joy  => #if bid > Ash #then Joy + bid - Ash #else Joy #fi
   sin[Vow]                  |-> Awe  => #if bid > Ash #then Awe - Ash #else Awe - bid #fi
+  dai[Vow]                  |-> Joy  => #if bid > Ash #then Joy + bid - Ash #else Joy #fi
   vice                      |-> Vice => #if bid > Ash #then Vice - Ash #else Vice - bid #fi
   debt                      |-> Debt => #if bid > Ash #then Debt - Ash #else Debt - bid #fi
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -271,7 +271,7 @@ interface add(uint256 x, int256 y) internal
 
 stack
 
-   #unsigned(y) : x : JMPTO : WS => JMPTO : x + y : WS
+   chop(y) : x : JMPTO : WS => JMPTO : x + y : WS
 
 iff in range uint256
 
@@ -288,7 +288,7 @@ interface sub(uint256 x, int256 y) internal
 
 stack
 
-    #unsigned(y) : x : JMPTO : WS => JMPTO : x - y : WS
+    chop(y) : x : JMPTO : WS => JMPTO : x - y : WS
 
 iff in range uint256
 
@@ -305,7 +305,7 @@ interface mul(uint256 x, int256 y) internal
 
 stack
 
-    #unsigned(y) : x : JMPTO : WS => JMPTO : #unsigned(x * y) : WS
+    chop(y) : x : JMPTO : WS => JMPTO : chop(x * y) : WS
 
 iff in range int256
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -1665,8 +1665,8 @@ for all
 
 storage
 
-    dai[CALLER_ID]   |-> Dai => Dai - rad
     sin[CALLER_ID]   |-> Sin => Sin - rad
+    dai[CALLER_ID]   |-> Dai => Dai - rad
     debt             |-> Debt  => Debt  - rad
     vice             |-> Vice  => Vice  - rad
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -1667,8 +1667,8 @@ storage
 
     sin[CALLER_ID]   |-> Sin => Sin - rad
     dai[CALLER_ID]   |-> Dai => Dai - rad
-    debt             |-> Debt  => Debt  - rad
     vice             |-> Vice  => Vice  - rad
+    debt             |-> Debt  => Debt  - rad
 
 iff
 
@@ -1705,8 +1705,8 @@ storage
     wards[CALLER_ID] |-> May
     sin[u]           |-> Sin_u => Sin_u + rad
     dai[v]           |-> Dai_v => Dai_v + rad
-    debt             |-> Debt  => Debt  + rad
     vice             |-> Vice  => Vice  + rad
+    debt             |-> Debt  => Debt  + rad
 
 iff
 
@@ -1744,11 +1744,11 @@ for all
 storage
 
     wards[CALLER_ID] |-> May
-    ilks[i].rate     |-> Rate_i => Rate_i + rate
     ilks[i].Art      |-> Art_i
+    live             |-> Live
+    ilks[i].rate     |-> Rate_i => Rate_i + rate
     dai[u]           |-> Dai_u => Dai_u + Art_i * rate
     debt             |-> Debt  => Debt  + Art_i * rate
-    live             |-> Live
 
 iff
 
@@ -4384,8 +4384,8 @@ storage
 
 storage Vat
 
-    dai[ACCT_ID] |-> Joy  => Joy  - rad
     sin[ACCT_ID] |-> Awe  => Awe  - rad
+    dai[ACCT_ID] |-> Joy  => Joy  - rad
     vice         |-> Vice => Vice - rad
     debt         |-> Debt => Debt - rad
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -10151,7 +10151,7 @@ storage
   vat      |-> Vat
   spot     |-> Spotter
   Art[ilk] |-> Art_i
-  tag[ilk] |-> Tag_i => (#Wad * Par) / Price
+  tag[ilk] |-> Tag_i => (Par * #Wad) / Price
 
 storage Spotter
   ilks[ilk].pip |-> DSValue
@@ -10178,7 +10178,7 @@ iff
   Price =/= 0
 
 iff in range uint256
-  #Wad * Par
+  Par * #Wad
 
 calls
   End.rdiv

--- a/src/dss.md
+++ b/src/dss.md
@@ -903,12 +903,12 @@ storage
     can[u][CALLER_ID] |-> Can_u
     can[v][CALLER_ID] |-> Can_v
     can[w][CALLER_ID] |-> Can_w
+    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
+    gem[i][v]         |-> Gem_iv   => Gem_iv  - dink
+    dai[w]            |-> Dai_w    => Dai_w + (Ilk_rate * dart)
     urns[i][u].ink    |-> Urn_ink  => Urn_ink + dink
     urns[i][u].art    |-> Urn_art  => Urn_art + dart
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art + dart
-    gem[i][v]         |-> Gem_iv   => Gem_iv  - dink
-    dai[w]            |-> Dai_w    => Dai_w + (Ilk_rate * dart)
-    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
     live              |-> Live
 
 iff in range uint256
@@ -988,12 +988,12 @@ storage
     can[u][CALLER_ID] |-> Can_u
     can[v][CALLER_ID] |-> Can_v
     can[w][CALLER_ID] |-> Can_w
+    debt              |-> Debt     => Debt
+    gem[i][v]         |-> Gem_iv   => Gem_iv  - dink
+    dai[w]            |-> Dai_w    => Dai_w
     urns[i][u].ink    |-> Urn_ink  => Urn_ink + dink
     urns[i][u].art    |-> Urn_art  => Urn_art
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art
-    gem[i][v]         |-> Gem_iv   => Gem_iv  - dink
-    dai[w]            |-> Dai_w    => Dai_w
-    debt              |-> Debt     => Debt
     live              |-> Live
 
 iff in range uint256
@@ -1065,12 +1065,12 @@ storage
     can[u][CALLER_ID] |-> Can_u
     can[v][CALLER_ID] |-> Can_v
     can[w][CALLER_ID] |-> Can_w
+    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
+    gem[i][v]         |-> Gem_iv   => Gem_iv
+    dai[w]            |-> Dai_w    => Dai_w + (Ilk_rate * dart)
     urns[i][u].ink    |-> Urn_ink  => Urn_ink
     urns[i][u].art    |-> Urn_art  => Urn_art + dart
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art + dart
-    gem[i][v]         |-> Gem_iv   => Gem_iv
-    dai[w]            |-> Dai_w    => Dai_w + (Ilk_rate * dart)
-    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
     live              |-> Live
 
 iff in range uint256
@@ -1146,12 +1146,12 @@ storage
     can[u][CALLER_ID] |-> Can_u
     can[v][CALLER_ID] |-> Can_v
     can[w][CALLER_ID] |-> Can_w
+    debt              |-> Debt     => Debt
+    gem[i][v]         |-> Gem_iv   => Gem_iv
+    dai[w]            |-> Dai_w    => Dai_w
     urns[i][u].ink    |-> Urn_ink  => Urn_ink
     urns[i][u].art    |-> Urn_art  => Urn_art
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art
-    gem[i][v]         |-> Gem_iv   => Gem_iv
-    dai[w]            |-> Dai_w    => Dai_w
-    debt              |-> Debt     => Debt
     live              |-> Live
 
 iff in range uint256
@@ -1214,12 +1214,12 @@ storage
     ilks[i].dust      |-> Ilk_dust
     Line              |-> Line
     can[u][CALLER_ID] |-> Can_u
+    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
+    gem[i][u]         |-> Gem_iu   => Gem_iu  - dink
+    dai[u]            |-> Dai_u    => Dai_u + (Ilk_rate * dart)
     urns[i][u].ink    |-> Urn_ink  => Urn_ink + dink
     urns[i][u].art    |-> Urn_art  => Urn_art + dart
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art + dart
-    gem[i][u]         |-> Gem_iu   => Gem_iu  - dink
-    dai[u]            |-> Dai_u    => Dai_u + (Ilk_rate * dart)
-    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
     live              |-> Live
 
 iff in range uint256
@@ -1291,12 +1291,12 @@ storage
     ilks[i].dust      |-> Ilk_dust
     Line              |-> Line
     can[u][CALLER_ID] |-> Can_u
+    debt              |-> Debt     => Debt
+    gem[i][u]         |-> Gem_iu   => Gem_iu  - dink
+    dai[u]            |-> Dai_u    => Dai_u
     urns[i][u].ink    |-> Urn_ink  => Urn_ink + dink
     urns[i][u].art    |-> Urn_art  => Urn_art
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art
-    gem[i][u]         |-> Gem_iu   => Gem_iu  - dink
-    dai[u]            |-> Dai_u    => Dai_u
-    debt              |-> Debt     => Debt
     live              |-> Live
 
 iff in range uint256
@@ -1364,12 +1364,12 @@ storage
     ilks[i].dust      |-> Ilk_dust
     Line              |-> Line
     can[u][CALLER_ID] |-> Can_u
+    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
+    gem[i][u]         |-> Gem_iu   => Gem_iu
+    dai[u]            |-> Dai_u    => Dai_u + (Ilk_rate * dart)
     urns[i][u].ink    |-> Urn_ink  => Urn_ink
     urns[i][u].art    |-> Urn_art  => Urn_art + dart
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art + dart
-    gem[i][u]         |-> Gem_iu   => Gem_iu
-    dai[u]            |-> Dai_u    => Dai_u + (Ilk_rate * dart)
-    debt              |-> Debt     => Debt  + (Ilk_rate * dart)
     live              |-> Live
 
 iff in range uint256
@@ -1439,12 +1439,12 @@ storage
     ilks[i].dust      |-> Ilk_dust
     Line              |-> Line
     can[u][CALLER_ID] |-> Can_u
+    debt              |-> Debt     => Debt
+    gem[i][u]         |-> Gem_iu   => Gem_iu
+    dai[u]            |-> Dai_u    => Dai_u
     urns[i][u].ink    |-> Urn_ink  => Urn_ink
     urns[i][u].art    |-> Urn_art  => Urn_art
     ilks[i].Art       |-> Ilk_Art  => Ilk_Art
-    gem[i][u]         |-> Gem_iu   => Gem_iu
-    dai[u]            |-> Dai_u    => Dai_u
-    debt              |-> Debt     => Debt
     live              |-> Live
 
 iff in range uint256

--- a/src/dss.md
+++ b/src/dss.md
@@ -2924,6 +2924,7 @@ gas
 
 This is the coinductive lemma.
 
+```
 0.    n % 2 == 0
       case: n >= 2
             n even

--- a/src/dss.md
+++ b/src/dss.md
@@ -4843,8 +4843,8 @@ storage Vat
     dai[Flapper] |-> Dai_f => 0
     dai[ACCT_ID] |-> Dai_v => 0
     sin[ACCT_ID] |-> Sin_v => Sin_v - (Dai_v + Dai_f)
-    vice |-> Vice => Vice - (Dai_v + Dai_f)
     debt |-> Debt => Debt - (Dai_v + Dai_f)
+    vice |-> Vice => Vice - (Dai_v + Dai_f)
 
 storage Flapper
 
@@ -4932,8 +4932,8 @@ storage Vat
     dai[Flapper] |-> Dai_f => 0
     dai[ACCT_ID] |-> Dai_v => 0
     sin[ACCT_ID] |-> Sin_v => 0
-    vice |-> Vice => Vice - Sin_v
     debt |-> Debt => Debt - (Dai_v + Dai_f)
+    vice |-> Vice => Vice - Sin_v
 
 storage Flapper
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -7807,8 +7807,8 @@ storage
 storage Vat
 
     can[CALLER_ID][ACCT_ID] |-> CanMove
-    dai[ACCT_ID]   |-> Dai_v => Dai_v + lot
     dai[CALLER_ID] |-> Dai_c => Dai_c - lot
+    dai[ACCT_ID]   |-> Dai_v => Dai_v + lot
 
 iff
 

--- a/src/dss.md
+++ b/src/dss.md
@@ -4265,9 +4265,9 @@ storage
 
     wards[CALLER_ID] |-> May
     wait             |-> Wait => (#if what == #string2Word("wait") #then data #else Wait #fi)
-    dump             |-> Dump => (#if what == #string2Word("dump") #then data #else Dump #fi)
-    sump             |-> Sump => (#if what == #string2Word("sump") #then data #else Sump #fi)
     bump             |-> Bump => (#if what == #string2Word("bump") #then data #else Bump #fi)
+    sump             |-> Sump => (#if what == #string2Word("sump") #then data #else Sump #fi)
+    dump             |-> Dump => (#if what == #string2Word("dump") #then data #else Dump #fi)
     hump             |-> Hump => (#if what == #string2Word("hump") #then data #else Hump #fi)
 
 iff
@@ -4434,8 +4434,8 @@ storage Vat
 
     sin[ACCT_ID] |-> Awe  => Awe  - rad
     dai[ACCT_ID] |-> Joy  => Joy  - rad
-    debt         |-> Debt => Debt - rad
     vice         |-> Vice => Vice - rad
+    debt         |-> Debt => Debt - rad
 
 iff
 
@@ -4568,8 +4568,8 @@ storage Flopper
 
     live                        |-> FlopLive
     wards[ACCT_ID]              |-> MayFlop
-    kicks                       |-> Kicks => 1 + Kicks
     ttl_tau                     |-> #WordPackUInt48UInt48(Ttl, Tau)
+    kicks                       |-> Kicks => 1 + Kicks
     bids[1 + Kicks].bid         |-> Bid => Sump
     bids[1 + Kicks].lot         |-> Lot => Dump
     bids[1 + Kicks].guy_tic_end |-> #WordPackAddrUInt48UInt48(Guy, Tic, End) => #WordPackAddrUInt48UInt48(ACCT_ID, Tic, TIME + Tau)
@@ -4659,12 +4659,12 @@ storage Flapper
 
     wards[ACCT_ID]              |-> VowMayFlap
     vat                         |-> FlapVat
-    kicks                       |-> Kicks   => 1 + Kicks
+    live                        |-> FlapLive
     ttl_tau                     |-> #WordPackUInt48UInt48(Ttl, Tau)
+    kicks                       |-> Kicks   => 1 + Kicks
     bids[1 + Kicks].bid         |-> Bid => 0
     bids[1 + Kicks].lot         |-> Lot => Bump
     bids[1 + Kicks].guy_tic_end |-> #WordPackAddrUInt48UInt48(Guy, Tic, End) => #WordPackAddrUInt48UInt48(ACCT_ID, Tic, TIME + Tau)
-    live                        |-> FlapLive
 
 storage Vat
 
@@ -4753,8 +4753,8 @@ storage Vat
     dai[Flapper] |-> Dai_f => 0
     dai[ACCT_ID] |-> Dai_v => (Dai_v + Dai_f) - Sin_v
     sin[ACCT_ID] |-> Sin_v => 0
-    debt |-> Debt => Debt - Sin_v
     vice |-> Vice => Vice - Sin_v
+    debt |-> Debt => Debt - Sin_v
 
 storage Flapper
 
@@ -4843,8 +4843,8 @@ storage Vat
     dai[Flapper] |-> Dai_f => 0
     dai[ACCT_ID] |-> Dai_v => 0
     sin[ACCT_ID] |-> Sin_v => Sin_v - (Dai_v + Dai_f)
-    debt |-> Debt => Debt - (Dai_v + Dai_f)
     vice |-> Vice => Vice - (Dai_v + Dai_f)
+    debt |-> Debt => Debt - (Dai_v + Dai_f)
 
 storage Flapper
 
@@ -4932,8 +4932,8 @@ storage Vat
     dai[Flapper] |-> Dai_f => 0
     dai[ACCT_ID] |-> Dai_v => 0
     sin[ACCT_ID] |-> Sin_v => 0
-    debt |-> Debt => Debt - (Dai_v + Dai_f)
     vice |-> Vice => Vice - Sin_v
+    debt |-> Debt => Debt - (Dai_v + Dai_f)
 
 storage Flapper
 


### PR DESCRIPTION
Fixes: makerdao/mkr-mcd-spec#225

This updates the specs to work with latest KEVM more easily, including:

-   Fixes to the write orders in several places (now that KLab generation is sensitive to write order).
-   Fixes to some arithmetic expressions that exist in some places.
-   Adds an explicit contract address dis-equality `Spotter =/= VowVat`
-   Fixes a markdown formatting error near the `Jug_rpow-loop` spec which causes KLab to get confused.
-   Removes all hardcoded gas expressions (because they are largely obsolete anyway).
-   Removes use of `#unsigned` in favor of direct use of `chop`.