### PR TITLE
README: install instructions for Solidity and DappHub Toolkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KLAB_OUT = out
 export KLAB_OUT
 
-PATH := $(CURDIR)/deps/klab/bin:$(PATH)
+PATH := $(CURDIR)/deps/klab/bin:$(CURDIR)/deps/evm-semantics/.build/usr/bin:$(PATH)
 export PATH
 
 include.mak: src/dss.md

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ If you want to build KEVM and KLab from source, you can:
     make kevm -j3
     ```
 
+### Setup Dapp Tools
+
+You need to install the [DappHub toolkit](https://dapp.tools/).
+This requires that you first install [Nix packager](https://nixos.org/download.html).
+For example, this may look like:
+
+```sh
+curl -L https://nixos.org/nix/install | sh
+source "$HOME/.nix-profile/etc/profile.d/nix.sh"
+curl https://dapp.tools/install | sh
+```
+
+Notice the middle `source` line which sets up the Nix environment for local usage.
+
 ### Running the Proofs
 
 To run all the proofs, you can use the `prove` target in the `Makefile`:

--- a/README.md
+++ b/README.md
@@ -8,31 +8,6 @@ These reachability claims are then tested against [KEVM](https://github.com/kfra
 Installation and Running
 ------------------------
 
-### Setup KLab and KEVM
-
-*Using external install of KLab/KEVM*:
-
--   Follow the install instructions of [KLab](https://github.com/makerdao/klab), including following the instructions for setting up KEVM included there.
--   Make sure that the `bin` directory inside the KLab repo is on `PATH` here.
--   Make sure that `KLAB_EVMS_PATH` is set as instructed if you are building KEVM from source (not needed if installed from package).
-
-*From-source builds in submodule*:
-
-If you want to build KEVM and KLab from source, you can:
-
--   Install the system dependencies of [KEVM](https://github.com/kframework/evm-semantics) and of [KLab](https://github.com/makerdao/klab).
--   Make sure that `PATH` is setup to include `$(pwd)/deps/klab/bin`.
--   Make sure that `KLAB_EVMS_PATH` is setup to include `$(pwd)/deps/evm-semanticss`.
--   Run the following:
-
-    ```sh
-    git submodule update --init --recursive
-    touch include.mak
-    make klab dapp
-    make include.mak -B
-    make kevm -j3
-    ```
-
 ### Setup Solidity Compiler and Dapp Tools
 
 First you'll need to install the [Nix packager](https://nixos.org/download.html).
@@ -52,6 +27,31 @@ And finally, install the [DappHub toolkit](https://dapp.tools/).
 ```sh
 curl https://dapp.tools/install | sh
 ```
+
+### Setup KLab and KEVM
+
+*Using external install of KLab/KEVM*:
+
+-   Follow the install instructions of [KLab](https://github.com/makerdao/klab), including following the instructions for setting up KEVM included there.
+-   Make sure that the `bin` directory inside the KLab repo is on `PATH` here.
+-   Make sure that `KLAB_EVMS_PATH` is set as instructed if you are building KEVM from source (not needed if installed from package).
+
+*From-source builds in submodule*:
+
+If you want to build KEVM and KLab from source, you can:
+
+-   Install the system dependencies of [KEVM](https://github.com/kframework/evm-semantics) and of [KLab](https://github.com/makerdao/klab).
+-   Make sure that `PATH` is setup to include `$(pwd)/deps/klab/bin`.
+-   Make sure that `KLAB_EVMS_PATH` is setup to include `$(pwd)/deps/evm-semantics`.
+-   Run the following:
+
+    ```sh
+    git submodule update --init --recursive
+    touch include.mak
+    make klab dapp
+    make include.mak -B
+    make kevm -j3
+    ```
 
 ### Running the Proofs
 

--- a/README.md
+++ b/README.md
@@ -33,19 +33,25 @@ If you want to build KEVM and KLab from source, you can:
     make kevm -j3
     ```
 
-### Setup Dapp Tools
+### Setup Solidity Compiler and Dapp Tools
 
-You need to install the [DappHub toolkit](https://dapp.tools/).
-This requires that you first install [Nix packager](https://nixos.org/download.html).
-For example, this may look like:
+First you'll need to install the [Nix packager](https://nixos.org/download.html).
 
 ```sh
 curl -L https://nixos.org/nix/install | sh
-source "$HOME/.nix-profile/etc/profile.d/nix.sh"
-curl https://dapp.tools/install | sh
 ```
 
-Notice the middle `source` line which sets up the Nix environment for local usage.
+Then you can install the Solidity compiler:
+
+```sh
+nix-env -f https://github.com/dapphub/dapptools/archive/master.tar.gz -iA solc-static-versions
+```
+
+And finally, install the [DappHub toolkit](https://dapp.tools/).
+
+```sh
+curl https://dapp.tools/install | sh
+```
 
 ### Running the Proofs
 


### PR DESCRIPTION
Fixes: https://github.com/makerdao/mkr-mcd-spec/issues/226

This adds explicit instructions for setting up the DappHub toolkit.